### PR TITLE
Add Zig build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ z64decompress "file-in.yaz" "file-out.bin" -c yaz -i
 ## Building
 I have included shell scripts for building Linux and Windows binaries. Windows binaries are built using a cross compiler ([I recommend `MXE`](https://mxe.cc/)).
 
+Zig may also be used for easy cross-compilation:
+```sh
+zig build -Dtarget=x86_64-linux-musl
+zig build -Dtarget=x86_64-windows
+zig build -Dtarget=aarch64-macos
+```

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const strip = b.option(bool, "strip", "remove debug symbols from executable") orelse false;
+
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "z64decompress",
+        .target = target,
+        .optimize = optimize,
+        .strip = strip,
+    });
+
+    exe.addCSourceFiles(.{
+        .files = &.{
+            "src/main.c",
+            "src/file.c",
+            "src/n64crc.c",
+            "src/wow.c",
+            "src/decoder/aplib.c",
+            "src/decoder/lzo.c",
+            "src/decoder/ucl.c",
+            "src/decoder/yaz.c",
+            "src/decoder/zlib.c",
+        },
+    });
+
+    exe.linkLibC();
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+}


### PR DESCRIPTION
Zig can be used for stupid-easy cross-compilation without need for installing extra toolchains, this allows building from any host to any target